### PR TITLE
Add periodic save functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ dependencies: ## Install dependencies requried for development operations.
 
 .PHONY: build
 build:
-	@go build -ldflags $(BUILDFLAGS) -o ./bin/$(NAME) ./main.go
+	@GOOS=darwin GOARCH=amd64 go build -ldflags $(BUILDFLAGS) -o ./bin/darwin/$(NAME) ./main.go
+	@GOOS=linux GOARCH=amd64 go build -ldflags $(BUILDFLAGS) -o bin/linux/$(NAME) ./main.go
 
 run="."
 dir="./..."

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -39,6 +39,14 @@ var (
 				Destination: &internal.Port,
 				EnvVars:     []string{internal.PortName},
 			},
+			&cli.DurationFlag{
+				Name:        "save-interval",
+				Aliases:     []string{"s"},
+				DefaultText: internal.DefaultSaveInterval.String(),
+				Value:       internal.DefaultSaveInterval,
+				Destination: &internal.SaveInterval,
+				EnvVars:     []string{internal.SaveIntervalName},
+			},
 		},
 		Action: func(_ *cli.Context) error {
 			cachePath := path.Join(internal.CachePath, internal.CacheName)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,22 +1,27 @@
 package internal
 
+import "time"
+
 const (
-	DebugName     = "HBT_DEBUG"
-	CachePathName = "HBT_CACHE"
-	PortName      = "HBT_PORT"
+	DebugName        = "HBT_DEBUG"
+	CachePathName    = "HBT_CACHE"
+	PortName         = "HBT_PORT"
+	SaveIntervalName = "HBT_SAVE_INTERVAL"
 )
 
 const (
 	// Found by looking at unused ports at:
 	// https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
-	DefaultPort      = "43111"
-	DefaultCachePath = "."
+	DefaultPort         = "43111"
+	DefaultCachePath    = "."
+	DefaultSaveInterval = time.Minute * 10
 )
 
 var (
-	Debug     bool
-	CachePath string
-	Port      string
+	Debug        bool
+	CachePath    string
+	Port         string
+	SaveInterval time.Duration
 	// Must be var, otherwise -X flag can't modify it
 	Version = "unknown"
 )

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	DebugName        = "HBT_DEBUG"
-	CachePathName    = "HBT_CACHE"
+	CachePathName    = "HBT_CACHE_PATH"
 	PortName         = "HBT_PORT"
 	SaveIntervalName = "HBT_SAVE_INTERVAL"
 )

--- a/zsh/hbt.zsh
+++ b/zsh/hbt.zsh
@@ -1,9 +1,10 @@
 # To be able to use zsh hooks
 autoload -Uz add-zsh-hook
 
-export PATH="$HOME/Repositories/hbt/bin:$PATH"
-HBT_CACHE_PATH=~/dotfiles/hbt/
-HBT_PORT=43111
+export PATH="$HOME/Repositories/hbt/bin/darwin:$PATH"
+export HBT_CACHE_PATH="$HOME/dotfiles/hbt/"
+export HBT_PORT=43111
+export HBT_SAVE_INTERVAL="10m"
 
 function hbt_start() {
 	pid=$(pgrep hbtsrv)


### PR DESCRIPTION
hbt now periodically saves the internal graph state. By default this happens every 10 minutes but it can be tweaked with the `HBT_SAVE_INTERVAL` environment variable.
Any valid [`time.Duration`](https://golang.org/pkg/time/#Duration) can be used.